### PR TITLE
[RD-24] Fix redirect link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There are many (too many!) ways to write React components so to make sure we all
 * [More info](#more-info)
 * [Naming conventions](#naming-conventions)
 * [File structure](#file-structure)
-* [GitFlow documentation](https://github.com/aurity/react-style-guidelines/tree/RD-24/docs/gitflow)
+* [GitFlow documentation](https://github.com/aurity/react-style-guidelines/tree/master/docs/gitflow)
 
 ## More info
 - Our code style is mainly based on AirBnb guidelines https://github.com/airbnb/javascript/blob/master/react/README.md


### PR DESCRIPTION
Fixed the redirection link (last time redirect to the TD-24 branch link).

Jira: 
https://aurity.atlassian.net/browse/RD-24

![redirect screen](https://i.gyazo.com/79ca06fed12ac082855a19fbf42399f1.png)




